### PR TITLE
[Don't merge] A test to show dotty-0.1.2-RC1.zip fail on windows

### DIFF
--- a/artifacts
+++ b/artifacts
@@ -1,2 +1,2 @@
-zip=https://github.com/liufengyun/packtest/releases/download/v0.2.0/dotty-0.2.0-bin-SNAPSHOT.zip
-tar=https://github.com/liufengyun/packtest/releases/download/v0.2.0/dotty-0.2.0-bin-SNAPSHOT.tar.gz
+zip=https://github.com/lampepfl/dotty/releases/download/0.1.2-RC1/dotty-0.1.2-RC1.zip
+tar=https://github.com/lampepfl/dotty/releases/download/0.1.2-RC1/dotty-0.1.2-RC1.tar.gz


### PR DESCRIPTION
A test to show dotty-0.1.2-RC1.zip fail on windows