### PR TITLE
update test for dotd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - bin/dotc examples/HelloWorld.scala
   - bin/dotr dotty.HelloWorld
   - echo ":quit" | bin/dotr
-  - bin/dotd examples/HelloWorld.scala
+  - bin/dotd -project Hello examples/HelloWorld.scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - bin/dotc examples/HelloWorld.scala
   - bin/dotr dotty.HelloWorld
   - echo ":quit" | bin/dotr
-  - mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala
+  - mkdir -p _site && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - bin/dotc examples/HelloWorld.scala
   - bin/dotr dotty.HelloWorld
   - echo ":quit" | bin/dotr
-  - - mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala
+  - mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - bin/dotc examples/HelloWorld.scala
   - bin/dotr dotty.HelloWorld
   - echo ":quit" | bin/dotr
-  - bin/dotd -project Hello examples/HelloWorld.scala
+  - - mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala

--- a/windows
+++ b/windows
@@ -4,4 +4,4 @@ bin/dotc @../examples/options ../examples/HelloWorld.scala
 bin/dotc ../examples/HelloWorld.scala
 bin/dotr dotty.HelloWorld
 # echo ":quit" | bin/dotr     # disable as it's not supported yet
-bin/dotd ../examples/HelloWorld.scala
+bin/dotd -project Hello ../examples/HelloWorld.scala

--- a/windows
+++ b/windows
@@ -4,4 +4,4 @@ bin/dotc @../examples/options ../examples/HelloWorld.scala
 bin/dotc ../examples/HelloWorld.scala
 bin/dotr dotty.HelloWorld
 # echo ":quit" | bin/dotr     # disable as it's not supported yet
-mkdir -p docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala
+mkdir -p _site && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala

--- a/windows
+++ b/windows
@@ -4,4 +4,4 @@ bin/dotc @../examples/options ../examples/HelloWorld.scala
 bin/dotc ../examples/HelloWorld.scala
 bin/dotr dotty.HelloWorld
 # echo ":quit" | bin/dotr     # disable as it's not supported yet
-mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala
+mkdir -p docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala

--- a/windows
+++ b/windows
@@ -4,4 +4,4 @@ bin/dotc @../examples/options ../examples/HelloWorld.scala
 bin/dotc ../examples/HelloWorld.scala
 bin/dotr dotty.HelloWorld
 # echo ":quit" | bin/dotr     # disable as it's not supported yet
-bin/dotd -project Hello ../examples/HelloWorld.scala
+mkdir docs && bin/dotd -siteroot docs -project Hello examples/HelloWorld.scala


### PR DESCRIPTION
update test for dotd

Without the option `-project Hello`, the command `bin/dotd` will fail silently. That's the reason why we didn't catch the error in packtest.